### PR TITLE
Fix single-arg `Coordinate()` constructor

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,9 @@ jobs:
           - '3.12'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -23,5 +23,4 @@ jobs:
       - name: Running flake8
         run: flake8 stgpytools
       - name: Running mypy
-        if: steps.dependencies.outcome == 'success'
         run: mypy stgpytools

--- a/stgpytools/enums/other.py
+++ b/stgpytools/enums/other.py
@@ -30,13 +30,16 @@ class Coordinate:
     def __init__(self: SelfCoord, x: int, y: int, /) -> None:
         ...
 
-    def __init__(self: SelfCoord, x_or_self: int | tuple[int, int] | SelfCoord, y: int, /) -> None:  # type: ignore
+    def __init__(self: SelfCoord, x_or_self: int | tuple[int, int] | SelfCoord, y: int | None = None, /) -> None:
         from ..exceptions import CustomValueError
 
         if isinstance(x_or_self, int):
             x = x_or_self
         else:
             x, y = x_or_self if isinstance(x_or_self, tuple) else (x_or_self.x, x_or_self.y)
+
+        if y is None:
+            raise CustomValueError("y coordinate must be defined!", self.__class__)
 
         if x < 0 or y < 0:
             raise CustomValueError("Values can't be negative!", self.__class__)


### PR DESCRIPTION
`Coordinate()` has a single-arg (not counting the `self` arg) constructor overload that is unusable because the overloaded constructor requires two args.

```py
from stgpytools import Coordinate
    
Coordinate((0, 0))
# TypeError: Coordinate.__init__() missing 1 required positional argument: 'y'
```

This is caught by mypy but the error was being `type: ignore`'d. This patch fixes the issue by making the `y` arg optional in the overloaded constructor's signature (but it's still required overall).

This was originally discovered via vs-masktool's `BoundingBox`:

```py
from vsmasktools import BoundingBox
    
BoundingBox((0, 0), (100, 100))
#   File "vs-masktools/vsmasktools/abstract.py", line 36, in __init__
#     self.pos, self.size, self.invert = Position(pos), Size(size), invert
#                                        ^^^^^^^^^^^^^
# TypeError: Coordinate.__init__() missing 1 required positional argument: 'y'
```